### PR TITLE
Added Ubuntu Wily (15.10) and Xenial (16.04)

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,5 +3,5 @@ Depends: python-argparse, python-catkin-pkg (>= 0.1.28), python-rosdistro (>= 0.
 Depends3: python3-catkin-pkg (>= 0.1.28), python3-rosdistro (>= 0.3.4), python3-rospkg, python3-yaml
 Conflicts: python3-rosinstall-generator
 Conflicts3: python-rosinstall-generator
-Suite: oneiric precise quantal raring saucy trusty utopic vivid wheezy jessie
+Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial wheezy jessie
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
Added Ubuntu Wily (15.10) and Xenial (16.04) to the list of supported platforms.