### PR TITLE
Change dependency distribute to setuptools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.3"
 # command to install dependencies
 install:
-  - pip install argparse catkin-pkg distribute rosdistro rospkg PyYAML
+  - pip install argparse catkin-pkg setuptools rosdistro rospkg PyYAML
 # command to run tests
 script:
 # This package doesn't have tests yet.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ exec(open(os.path.join(os.path.dirname(__file__), 'src', 'rosinstall_generator',
 setup(
     name='rosinstall_generator',
     version=__version__,
-    install_requires=['argparse', 'catkin_pkg >= 0.1.28', 'distribute', 'rosdistro >= 0.3.4', 'rospkg', 'PyYAML'],
+    install_requires=['argparse', 'catkin_pkg >= 0.1.28', 'setuptools', 'rosdistro >= 0.3.4', 'rospkg', 'PyYAML'],
     packages=find_packages('src'),
     package_dir={'': 'src'},
     scripts=['bin/rosinstall_generator'],


### PR DESCRIPTION
Removed the outdated dependency "distribute" and use "setuptools" instead in the hope that it would solve #34. Since there are no test and I am on OSX, I am not able to certify that it works as expected. Could someone confirm ?