### PR TITLE
Change the tarball generator to work with bitbucket and gitlab URLs.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+include =
+    src/rosinstall_generator/*
+
+[report]
+show_missing = True

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ deb_dist
 dist
 *.pyc
 rosinstall_generator.egg-info
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
 language: python
+sudo: false
+
 python:
   - "2.6"
   - "2.7"
   - "3.3"
-# command to install dependencies
+
 install:
-  - pip install argparse catkin-pkg rosdistro rospkg PyYAML setuptools
-# command to run tests
+  - pip install argparse catkin-pkg rosdistro rospkg PyYAML setuptools coverage
+
 script:
-# This package doesn't have tests yet.
-  - true # - nosetests -s --tests test
+  - nosetests --with-coverage
+
 notifications:
   email: false

--- a/src/rosinstall_generator/distro.py
+++ b/src/rosinstall_generator/distro.py
@@ -138,7 +138,7 @@ def _generate_rosinstall(local_name, url, release_tag, tar=False, vcs_type=None)
     if tar:
         # Github tarball:    https://github.com/ros/ros_comm/archive/1.11.20.tar.gz
         # Bitbucket tarball: https://bitbucket.org/osrf/gazebo/get/gazebo7_7.3.1.tar.gz
-        # Gitlab tarball:    http://gitlab.example.com/org/repo/repository/archive.tar.gz?ref=0.5.3
+        # Gitlab tarball:    https://gitlab.com/gitlab-org/gitlab-ce/repository/archive.tar.gz?ref=master
         match = re.match('(?:https?:\/\/|ssh:\/\/|git:\/\/|git@)([\w.-]+)[:/]([\w/-]*)(?:\.git)?$', url)
 
         if match:

--- a/src/rosinstall_generator/distro.py
+++ b/src/rosinstall_generator/distro.py
@@ -139,7 +139,7 @@ def _generate_rosinstall(local_name, url, release_tag, tar=False, vcs_type=None)
         # Github tarball:    https://github.com/ros/ros_comm/archive/1.11.20.tar.gz
         # Bitbucket tarball: https://bitbucket.org/osrf/gazebo/get/gazebo7_7.3.1.tar.gz
         # Gitlab tarball:    https://gitlab.com/gitlab-org/gitlab-ce/repository/archive.tar.gz?ref=master
-        match = re.match('(?:https?:\/\/|ssh:\/\/|git:\/\/|git@)([\w.-]+)[:/]([\w/-]*)(?:\.git)?$', url)
+        match = re.match('(?:\w+:\/\/|git@)([\w.-]+)[:/]([\w/-]*)(?:\.git)?$', url)
 
         if match:
             server, repo_path = match.groups()
@@ -155,13 +155,13 @@ def _generate_rosinstall(local_name, url, release_tag, tar=False, vcs_type=None)
                         'uri': tarball_url_template.format(server, repo_path, release_tag),
                         'version': '{0}-{1}'.format(os.path.basename(repo_path), release_tag.replace('/', '-'))
                     }}]
-            logger.log(logging.WARN, 'Tarball requested for repo {0}, but git server {1} is unrecognized. '.format(
+            logger.log(logging.WARN, "Tarball requested for repo '{0}', but git server '{1}' is unrecognized.".format(
                 local_name, server))
         else:
-            logger.log(logging.WARN, 'Tarball requested for repo {0}, but I can\'t parse git URL {1}. '.format(
+            logger.log(logging.WARN, "Tarball requested for repo '{0}', but I can't parse git URL '{1}'.".format(
                 local_name, url))
 
-        logger.log(logging.WARN, 'Falling back on git clone for repo {0}'.format(local_name))
+        logger.log(logging.WARN, "Falling back on git clone for repo '{0}'.".format(local_name))
 
     return [{ vcs_type or 'git': {
         'local-name': local_name,

--- a/src/rosinstall_generator/distro.py
+++ b/src/rosinstall_generator/distro.py
@@ -33,6 +33,7 @@
 
 import logging
 import os
+import re
 import sys
 
 from rosdistro import get_cached_distribution, get_index, get_index_url
@@ -132,26 +133,38 @@ def _generate_rosinstall_for_package(distro, pkg_name, flat=False, tar=False):
 
 
 def _generate_rosinstall(local_name, url, release_tag, tar=False, vcs_type=None):
+    logger = logging.getLogger('rosinstall_generator.generate')
+
     if tar:
-        # the repository name might be different than repo.name coming from rosdistro
-        repo_name = os.path.basename(url[:-4])
-        suffix = '.git'
-        if not url.endswith(suffix):
-            raise RuntimeError("The repository '%s' must end with '%s': %s" % (repo_name, suffix, url))
-        url = url[:-len(suffix)] + '/archive/{0}.tar.gz'.format(release_tag)
-        data = [{
-            'tar': {
-                'local-name': local_name,
-                'uri': url,
-                'version': '{0}-{1}'.format(repo_name, release_tag.replace('/', '-'))
+        # Github tarball:    https://github.com/ros/ros_comm/archive/1.11.20.tar.gz
+        # Bitbucket tarball: https://bitbucket.org/osrf/gazebo/get/gazebo7_7.3.1.tar.gz
+        # Gitlab tarball:    http://gitlab.example.com/org/repo/repository/archive.tar.gz?ref=0.5.3
+        match = re.match('(?:https?:\/\/|ssh:\/\/|git:\/\/|git@)([\w.-]+)[:/]([\w/-]*)(?:\.git)?$', url)
+
+        if match:
+            server, repo_path = match.groups()
+            url_templates = {
+                'github': 'https://{0}/{1}/archive/{2}.tar.gz',
+                'bitbucket': 'https://{0}/{1}/get/{2}.tar.gz',
+                'gitlab': 'https://{0}/{1}/repository/archive.tar.gz?ref={2}'
             }
-        }]
-    else:
-        data = [{
-            vcs_type or 'git': {
-                'local-name': local_name,
-                'uri': url,
-                'version': release_tag
-            }
-        }]
-    return data
+            for server_key, tarball_url_template in url_templates.items():
+                if server_key in server:
+                    return [{ 'tar': {
+                        'local-name': local_name,
+                        'uri': tarball_url_template.format(server, repo_path, release_tag),
+                        'version': '{0}-{1}'.format(os.path.basename(repo_path), release_tag.replace('/', '-'))
+                    }}]
+            logger.log(logging.WARN, 'Tarball requested for repo {0}, but git server {1} is unrecognized. '.format(
+                local_name, server))
+        else:
+            logger.log(logging.WARN, 'Tarball requested for repo {0}, but I can\'t parse git URL {1}. '.format(
+                local_name, url))
+
+        logger.log(logging.WARN, 'Falling back on git clone for repo {0}'.format(local_name))
+
+    return [{ vcs_type or 'git': {
+        'local-name': local_name,
+        'uri': url,
+        'version': release_tag
+    }}]

--- a/test/test_distro.py
+++ b/test/test_distro.py
@@ -1,0 +1,101 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2016, Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Open Source Robotics Foundation, Inc. nor
+#    the names of its contributors may be used to endorse or promote
+#    products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import yaml
+
+from rosinstall_generator.distro import generate_rosinstall, get_package_names
+from rosdistro.distribution_file import DistributionFile
+
+
+def _get_test_dist():
+    test_dist_yaml = '''
+      repositories:
+        riverdale:
+          release:
+            packages:
+            - archie
+            - betty
+            - veronica
+            tags:
+              release: release/indigo/{package}/{version}
+            url: https://example.com/riverdale-release.git
+            version: 1.2.3-0
+      type: distribution
+      version: 2
+    '''
+    return DistributionFile('test', yaml.load(test_dist_yaml))
+
+
+def test_get_package_names():
+    d = _get_test_dist()
+    assert set(get_package_names(d)[0]) == set(['archie', 'betty', 'veronica'])
+
+    d.repositories['riverdale'].release_repository.version = None
+    assert set(get_package_names(d)[1]) == set(['archie', 'betty', 'veronica'])
+
+
+def test_generate_git():
+    d = _get_test_dist()
+    r = generate_rosinstall(d, ['betty'])[0]
+    assert r['git']['local-name'] == 'riverdale/betty'
+    assert r['git']['version'] == 'release/indigo/betty/1.2.3-0'
+    assert r['git']['uri'] == 'https://example.com/riverdale-release.git'
+
+    r = generate_rosinstall(d, ['betty'], flat=True)[0]
+    assert r['git']['local-name'] == 'betty'
+
+
+def test_generate_tar():
+    d = _get_test_dist()
+
+    r = generate_rosinstall(d, ['archie'], tar=True)[0]
+    assert 'tar' not in r
+
+    d.repositories['riverdale'].release_repository.url = 'https://github.com/example/riverdale-release.git'
+    r = generate_rosinstall(d, ['archie'], tar=True)[0]
+    assert r['tar']['uri'] == 'https://github.com/example/riverdale-release/archive/release/indigo/archie/1.2.3-0.tar.gz'
+
+    d.repositories['riverdale'].release_repository.url = 'https://bitbucket.org/example/riverdale-release.git'
+    r = generate_rosinstall(d, ['archie'], tar=True)[0]
+    assert r['tar']['uri'] == 'https://bitbucket.org/example/riverdale-release/get/release/indigo/archie/1.2.3-0.tar.gz'
+
+    d.repositories['riverdale'].release_repository.url = 'https://gitlab.example.com/example/riverdale-release.git'
+    r = generate_rosinstall(d, ['archie'], tar=True)[0]
+    assert r['tar']['uri'] == 'https://gitlab.example.com/example/riverdale-release/repository/archive.tar.gz?ref=release/indigo/archie/1.2.3-0'
+
+
+def test_generate_tar_from_ssh():
+    d = _get_test_dist()
+    d.repositories['riverdale'].release_repository.url = 'git@gitlab.example.com:example/riverdale-release.git'
+    r = generate_rosinstall(d, ['archie'], tar=True)[0]
+    assert r['tar']['uri'] == 'https://gitlab.example.com/example/riverdale-release/repository/archive.tar.gz?ref=release/indigo/archie/1.2.3-0'

--- a/test/test_distro.py
+++ b/test/test_distro.py
@@ -1,6 +1,6 @@
 # Software License Agreement (BSD License)
 #
-# Copyright (c) 2016, Open Source Robotics Foundation, Inc.
+# Copyright (c) 2016, Mike Purvis
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Since there's no standard scheme for getting a tarball URL from a git repo, this at least generalizes  the github-centric logic to also cover bitbucket and gitlab. Simple tests from our in-house rosdistro:

```
$ rosinstall_generator actionlib --tar --rosdistro indigo
- tar:
    local-name: actionlib
    uri: https://gitlab.clearpathrobotics.com/gbp/actionlib-gbp/repository/archive.tar.gz?ref=release/indigo/actionlib/1.11.5-1
    version: actionlib-gbp-release-indigo-actionlib-1.11.5-1
$ rosinstall_generator actionlib --tar --rosdistro indigo --upstream-development
- tar:
    local-name: actionlib
    uri: https://github.com/clearpathrobotics/actionlib/archive/indigo-devel.tar.gz
    version: actionlib-indigo-devel
$ rosinstall_generator cpr_navigation --tar --rosdistro indigo
- tar:
    local-name: cpr_navigation/cpr_navigation
    uri: https://bitbucket.org/clearpathrobotics/cpr_navigation-gbp/get/release/indigo/cpr_navigation/2.0.6-0.tar.gz
    version: cpr_navigation-gbp-release-indigo-cpr_navigation-2.0.6-0
```

To confirm the failure path, I manually mutated a local copy of my indigo cache, and got:

```
$ rosinstall_generator actionlib --tar --rosdistro indigo > foo.txt
Tarball requested for repo actionlib, but git server gatlab.clearpathrobotics.com is unrecognized.
Falling back on git clone for repo actionlib
$ cat foo.txt
- git:
    local-name: actionlib
    uri: git@gatlab.clearpathrobotics.com:gbp/actionlib-gbp.git
    version: release/indigo/actionlib/1.11.5-1
```

Once https://github.com/ros-infrastructure/rosdistro/pull/79 eventually merges, this could be refactored to take advantage of `RepositorySpecification.VCS_REGEX`, but it's only a small savings, so I think I'd rather get this in now than wait for that.