### PR TITLE
Use SourceDependencyWalker from rosdistro 0.5.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ python:
   - "3.3"
 
 install:
-  - pip install https://github.com/ros-infrastructure/rosdistro/archive/master.tar.gz
-  - pip install argparse catkin-pkg rospkg PyYAML setuptools coverage
+  - pip install argparse catkin-pkg rosdistro rospkg PyYAML setuptools coverage
 
 script:
   - nosetests --with-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ python:
   - "3.3"
 
 install:
-  - pip install argparse catkin-pkg rosdistro rospkg PyYAML setuptools coverage
+  - pip install https://github.com/ros-infrastructure/rosdistro/archive/master.tar.gz
+  - pip install argparse catkin-pkg rospkg PyYAML setuptools coverage
 
 script:
   - nosetests --with-coverage

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ exec(open(os.path.join(os.path.dirname(__file__), 'src', 'rosinstall_generator',
 setup(
     name='rosinstall_generator',
     version=__version__,
-    install_requires=['argparse', 'catkin_pkg >= 0.1.28', 'rosdistro >= 0.4.8', 'rospkg', 'PyYAML', 'setuptools'],
+    install_requires=['argparse', 'catkin_pkg >= 0.1.28', 'rosdistro >= 0.5.0', 'rospkg', 'PyYAML', 'setuptools'],
     packages=find_packages('src'),
     package_dir={'': 'src'},
     scripts=['bin/rosinstall_generator'],

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ exec(open(os.path.join(os.path.dirname(__file__), 'src', 'rosinstall_generator',
 setup(
     name='rosinstall_generator',
     version=__version__,
-    install_requires=['argparse', 'catkin_pkg >= 0.1.28', 'rosdistro >= 0.3.4', 'rospkg', 'PyYAML', 'setuptools'],
+    install_requires=['argparse', 'catkin_pkg >= 0.1.28', 'rosdistro >= 0.4.8', 'rospkg', 'PyYAML', 'setuptools'],
     packages=find_packages('src'),
     package_dir={'': 'src'},
     scripts=['bin/rosinstall_generator'],

--- a/src/rosinstall_generator/generator.py
+++ b/src/rosinstall_generator/generator.py
@@ -342,7 +342,8 @@ def generate_rosinstall(distro_name, names,
             wet_distro = get_wet_distro(distro_name)
             _, unreleased_package_names = get_package_names(wet_distro)
             excludes = exclude_names.wet_package_names | deps_up_to_names.wet_package_names | set(unreleased_package_names)
-            result.wet_package_names |= get_recursive_dependencies_of_wet(wet_distro, result.wet_package_names, excludes=excludes, limit_depth=deps_depth)
+            result.wet_package_names |= get_recursive_dependencies_of_wet(wet_distro, result.wet_package_names, excludes=excludes,
+                    limit_depth=deps_depth, source=upstream_source_version)
             logger.debug('Wet packages including dependencies: %s' % ', '.join(sorted(result.wet_package_names)))
 
     # intersect result with recursive dependencies on
@@ -351,7 +352,8 @@ def generate_rosinstall(distro_name, names,
         if deps_up_to_names.wet_package_names:
             wet_distro = get_wet_distro(distro_name)
             # wet depends on do not include the names since they are excluded to stop recursion asap
-            wet_package_names = get_recursive_dependencies_on_of_wet(wet_distro, deps_up_to_names.wet_package_names, excludes=names.wet_package_names, limit=result.wet_package_names)
+            wet_package_names = get_recursive_dependencies_on_of_wet(wet_distro, deps_up_to_names.wet_package_names, excludes=names.wet_package_names,
+                    limit=result.wet_package_names, source=upstream_source_version)
             # keep all names which are already in the result set
             wet_package_names |= result.wet_package_names & names.wet_package_names
             result.wet_package_names = wet_package_names


### PR DESCRIPTION
Follow-on to https://github.com/ros-infrastructure/rosdistro/pull/84

When the distro includes a source cache, use the walker which resolves dependencies using it, otherwise fall back on resolving deps using the release package XMLs (the previous behaviour).

@dirk-thomas
