### PR TITLE
WIP: Fix CLI use for source-only rosdistros.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 import sys
 from setuptools import setup, find_packages
 
-install_requires=['catkin_pkg >= 0.1.28', 'rosdistro >= 0.6.7', 'rospkg', 'PyYAML', 'setuptools']
+install_requires=['catkin_pkg >= 0.1.28', 'rosdistro >= 0.6.8', 'rospkg', 'PyYAML', 'setuptools']
 
 # argparse is a part of the standard library since python 2.7
 if sys.version_info[0] == 2 and sys.version_info[1] <= 6:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ exec(open(os.path.join(os.path.dirname(__file__), 'src', 'rosinstall_generator',
 setup(
     name='rosinstall_generator',
     version=__version__,
-    install_requires=['argparse', 'catkin_pkg >= 0.1.28', 'rosdistro >= 0.5.0', 'rospkg', 'PyYAML', 'setuptools'],
+    install_requires=['argparse', 'catkin_pkg >= 0.1.28', 'rosdistro >= 0.6.7', 'rospkg', 'PyYAML', 'setuptools'],
     packages=find_packages('src'),
     package_dir={'': 'src'},
     scripts=['bin/rosinstall_generator'],

--- a/src/rosinstall_generator/generator.py
+++ b/src/rosinstall_generator/generator.py
@@ -87,20 +87,27 @@ def _classify_repo_names(distro_name, repo_names):
     return names, unknown_names
 
 
-def _get_packages_for_repos(distro_name, repo_names):
+def _get_packages_for_repos(distro_name, repo_names, source=False):
     package_names = set([])
     unreleased_repo_names = set([])
     wet_distro = get_wet_distro(distro_name)
     for repo_name in repo_names:
-        release_repo = wet_distro.repositories[repo_name].release_repository
-        if release_repo:
-            package_names.update(release_repo.package_names)
+        if source:
+            source_package_xmls = wet_distro.get_source_repo_package_xmls(repo_name)
+        if source and source_package_xmls:
+            source_package_names = source_package_xmls.keys()
+            source_package_names.remove("_ref")
+            package_names.update(source_package_names)
         else:
-            unreleased_repo_names.add(repo_name)
+            release_repo = wet_distro.repositories[repo_name].release_repository
+            if release_repo:
+                package_names.update(release_repo.package_names)
+            else:
+                unreleased_repo_names.add(repo_name)
     return package_names, unreleased_repo_names
 
 
-def _classify_names(distro_name, names):
+def _classify_names(distro_name, names, source=False):
     unknown_names = set(names or [])
 
     wet_package_names = set([])
@@ -110,8 +117,9 @@ def _classify_names(distro_name, names):
     # identify wet packages
     if unknown_names:
         wet_distro = get_wet_distro(distro_name)
+        packages = wet_distro.source_packages if source else wet_distro.release_packages
         for name in unknown_names:
-            if name in wet_distro.release_packages:
+            if name in packages:
                 wet_package_names.add(name)
         unknown_names -= wet_package_names
 
@@ -246,7 +254,7 @@ def generate_rosinstall(distro_name, names,
     repo_names, unknown_repo_names = _classify_repo_names(distro_name, repo_names)
     if unknown_repo_names:
         logger.warn('The following unknown repositories will be ignored: %s' % (', '.join(sorted(unknown_repo_names))))
-    wet_package_names, unreleased_repo_names = _get_packages_for_repos(distro_name, repo_names)
+    wet_package_names, unreleased_repo_names = _get_packages_for_repos(distro_name, repo_names, source=upstream_source_version)
     names.update(wet_package_names)
     if unreleased_repo_names and not upstream_version_tag and not upstream_source_version:
         logger.warn('The following unreleased repositories will be ignored: %s' % ', '.join(sorted(unreleased_repo_names)))
@@ -254,11 +262,11 @@ def generate_rosinstall(distro_name, names,
         logger.warn('The dependencies of the following unreleased repositories are unknown and will be ignored: %s' % ', '.join(sorted(unreleased_repo_names)))
     has_repos = ((repo_names - unreleased_repo_names) and (upstream_version_tag or upstream_source_version)) or (unreleased_repo_names and upstream_source_version)
 
-    names, unknown_names = _classify_names(distro_name, names)
+    names, unknown_names = _classify_names(distro_name, names, source=upstream_source_version)
     if unknown_names:
         logger.warn('The following not released packages/stacks will be ignored: %s' % (', '.join(sorted(unknown_names))))
     if keywords:
-        expanded_names, unknown_names = _classify_names(distro_name, _expand_keywords(distro_name, keywords))
+        expanded_names, unknown_names = _classify_names(distro_name, _expand_keywords(distro_name, keywords), source=upstream_source_version)
         if unknown_names:
             logger.warn('The following not released packages/stacks from the %s will be ignored: %s' % (ROS_PACKAGE_PATH, ', '.join(sorted(unknown_names))))
         names.update(expanded_names)
@@ -271,11 +279,11 @@ def generate_rosinstall(distro_name, names,
 
     # classify deps-up-to
     deps_up_to_names, keywords = _split_special_keywords(deps_up_to or [])
-    deps_up_to_names, unknown_names = _classify_names(distro_name, deps_up_to_names)
+    deps_up_to_names, unknown_names = _classify_names(distro_name, deps_up_to_names, source=upstream_source_version)
     if unknown_names:
         logger.warn("The following not released '--deps-up-to' packages/stacks will be ignored: %s" % (', '.join(sorted(unknown_names))))
     if keywords:
-        expanded_names, unknown_names = _classify_names(distro_name, _expand_keywords(distro_name, keywords))
+        expanded_names, unknown_names = _classify_names(distro_name, _expand_keywords(distro_name, keywords), source=upstream_source_version)
         if unknown_names:
             logger.warn("The following not released '--deps-up-to' packages/stacks from the %s will be ignored: %s" % (ROS_PACKAGE_PATH, ', '.join(sorted(unknown_names))))
         deps_up_to_names.update(expanded_names)
@@ -289,11 +297,11 @@ def generate_rosinstall(distro_name, names,
         [exclude_names_from_path.update(_get_package_names(exclude_path)) for exclude_path in exclude_paths]
         logger.debug("The following wet packages found in '--exclude-path' will be excluded: %s" % ', '.join(sorted(exclude_names_from_path)))
         exclude_names.update(exclude_names_from_path)
-    exclude_names, unknown_names = _classify_names(distro_name, exclude_names)
+    exclude_names, unknown_names = _classify_names(distro_name, exclude_names, source=upstream_source_version)
     if unknown_names:
         logger.warn("The following not released '--exclude' packages/stacks will be ignored: %s" % (', '.join(sorted(unknown_names))))
     if keywords:
-        expanded_names, unknown_names = _classify_names(distro_name, _expand_keywords(distro_name, keywords))
+        expanded_names, unknown_names = _classify_names(distro_name, _expand_keywords(distro_name, keywords), source=upstream_source_version)
         exclude_names.update(expanded_names)
     if excludes:
         logger.debug('Excluded packages/stacks: %s' % ', '.join(sorted(exclude_names.wet_package_names | exclude_names.dry_stack_names)))
@@ -402,12 +410,16 @@ def generate_rosinstall(distro_name, names,
             # determine repositories based on package names and passed in repository names
             repos = {}
             for pkg_name in result.wet_package_names:
-                pkg = wet_distro.release_packages[pkg_name]
-                if pkg.repository_name not in repos:
-                    repo = wet_distro.repositories[pkg.repository_name]
-                    release_repo = repo.release_repository
-                    assert not upstream_version_tag or release_repo.version is not None, "Package '%s' in repository '%s' does not have a release version" % (pkg_name, pkg.repository_name)
-                    repos[pkg.repository_name] = repo
+                if upstream_source_version:
+                    pkg = wet_distro.source_packages[pkg_name]
+                    repos[pkg.repository_name] = wet_distro.repositories[pkg.repository_name]
+                else:
+                    pkg = wet_distro.release_packages[pkg_name]
+                    if pkg.repository_name not in repos:
+                        repo = wet_distro.repositories[pkg.repository_name]
+                        release_repo = repo.release_repository
+                        assert not upstream_version_tag or release_repo.version is not None, "Package '%s' in repository '%s' does not have a release version" % (pkg_name, pkg.repository_name)
+                        repos[pkg.repository_name] = repo
             for repo_name in repo_names:
                 if repo_name not in repos:
                     repos[repo_name] = wet_distro.repositories[repo_name]

--- a/src/rosinstall_generator/generator.py
+++ b/src/rosinstall_generator/generator.py
@@ -93,16 +93,10 @@ def _get_packages_for_repos(distro_name, repo_names, source=False):
     wet_distro = get_wet_distro(distro_name)
     for repo_name in repo_names:
         if source:
-            # Returns a dict which maps package names to their package XML strings as stored in the cache,
-            # and also includes a special "_ref" key which stores the SHA of the repo state which corresponds
-            # to when these versions of the package.xml strings were captured.
+            # Returns a mapping of package names to package XML strings in particular repo.
             source_package_xmls = wet_distro.get_source_repo_package_xmls(repo_name)
         if source and source_package_xmls:
-            source_package_names = source_package_xmls.keys()
-            # Remove the unneeded _ref key from the dict, since it does not correspond to an actual package
-            # name. See: https://github.com/ros-infrastructure/rosdistro/issues/116
-            source_package_names.remove("_ref")
-            package_names.update(source_package_names)
+            package_names.update(source_package_xmls.keys())
         else:
             release_repo = wet_distro.repositories[repo_name].release_repository
             if release_repo:

--- a/src/rosinstall_generator/generator.py
+++ b/src/rosinstall_generator/generator.py
@@ -117,7 +117,7 @@ def _classify_names(distro_name, names, source=False):
     # identify wet packages
     if unknown_names:
         wet_distro = get_wet_distro(distro_name)
-        packages = wet_distro.source_packages if source else wet_distro.release_packages
+        packages = wet_distro.source_packages if source and wet_distro.source_packages else wet_distro.release_packages
         for name in unknown_names:
             if name in packages:
                 wet_package_names.add(name)
@@ -410,7 +410,7 @@ def generate_rosinstall(distro_name, names,
             # determine repositories based on package names and passed in repository names
             repos = {}
             for pkg_name in result.wet_package_names:
-                if upstream_source_version:
+                if upstream_source_version and wet_distro.source_packages:
                     pkg = wet_distro.source_packages[pkg_name]
                     repos[pkg.repository_name] = wet_distro.repositories[pkg.repository_name]
                 else:

--- a/src/rosinstall_generator/generator.py
+++ b/src/rosinstall_generator/generator.py
@@ -93,9 +93,14 @@ def _get_packages_for_repos(distro_name, repo_names, source=False):
     wet_distro = get_wet_distro(distro_name)
     for repo_name in repo_names:
         if source:
+            # Returns a dict which maps package names to their package XML strings as stored in the cache,
+            # and also includes a special "_ref" key which stores the SHA of the repo state which corresponds
+            # to when these versions of the package.xml strings were captured.
             source_package_xmls = wet_distro.get_source_repo_package_xmls(repo_name)
         if source and source_package_xmls:
             source_package_names = source_package_xmls.keys()
+            # Remove the unneeded _ref key from the dict, since it does not correspond to an actual package
+            # name. See: https://github.com/ros-infrastructure/rosdistro/issues/116
             source_package_names.remove("_ref")
             package_names.update(source_package_names)
         else:

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
-Depends: python-argparse, python-catkin-pkg (>= 0.1.28), python-rosdistro (>= 0.5.0), python-rospkg, python-yaml
-Depends3: python3-catkin-pkg (>= 0.1.28), python3-rosdistro (>= 0.5.0), python3-rospkg, python3-yaml
+Depends: python-argparse, python-catkin-pkg (>= 0.1.28), python-rosdistro (>= 0.6.7), python-rospkg, python-yaml
+Depends3: python3-catkin-pkg (>= 0.1.28), python3-rosdistro (>= 0.6.7), python3-rospkg, python3-yaml
 Conflicts: python3-rosinstall-generator
 Conflicts3: python-rosinstall-generator
 Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic wheezy jessie stretch buster

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
-Depends: python-argparse, python-catkin-pkg (>= 0.1.28), python-rosdistro (>= 0.6.7), python-rospkg, python-yaml
-Depends3: python3-catkin-pkg (>= 0.1.28), python3-rosdistro (>= 0.6.7), python3-rospkg, python3-yaml
+Depends: python-argparse, python-catkin-pkg (>= 0.1.28), python-rosdistro (>= 0.6.8), python-rospkg, python-yaml
+Depends3: python3-catkin-pkg (>= 0.1.28), python3-rosdistro (>= 0.6.8), python3-rospkg, python3-yaml
 Conflicts: python3-rosinstall-generator
 Conflicts3: python-rosinstall-generator
 Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic wheezy jessie stretch buster


### PR DESCRIPTION
Since we finished the process of transitioning away from using Bloom, we no longer have release stanzas in our rosdistro repo— it's exclusively tagged source repos. I noticed today that under these circumstances, `rosinstall_generator` was broken at the command line, which we hadn't noticed previously because our build tooling uses it by importing and calling the underlying functions directly (which among other things bypasses a lot of the wet/dry compatibility stuff).

Anyway, this fix allows the following invocations to work on a source-only rosdistro where an appropriate source cache is available. Example specifying repos with dependencies:

```
$ rosinstall_generator --rosdistro indigo --upstream-development --deps --repos ros_comm
- git:
    local-name: catkin
    uri: https://github.com/ros/catkin.git
    version: 0.7.8
[...]
- git:
    local-name: ros_comm
    uri: https://github.com/ros/ros_comm.git
    version: e69b098bd4d80e7c8feda1eb1a9aaf67cdac352e
- git:
    local-name: ros_comm_msgs
    uri: https://github.com/ros/ros_comm_msgs.git
    version: 1.11.2
- git:
    local-name: roscpp_core
    uri: https://github.com/ros/roscpp_core.git
    version: 0.6.7
- git:
    local-name: roslisp
    uri: https://github.com/ros/roslisp.git
    version: 1.9.21
- git:
    local-name: rospack
    uri: https://github.com/ros/rospack.git
    version: 2.2.8
- git:
    local-name: std_msgs
    uri: https://github.com/ros/std_msgs.git
    version: 0.5.11
```

Example specifying exact package with deps, getting tarballs:

```
$ rosinstall_generator --rosdistro indigo --upstream-development --deps --tar rospack
- tar:
    local-name: catkin
    uri: https://github.com/ros/catkin/archive/0.7.8.tar.gz
    version: catkin-0.7.8
- tar:
    local-name: cmake_modules
    uri: https://github.com/ros/cmake_modules/archive/0.4.1.tar.gz
    version: cmake_modules-0.4.1
- tar:
    local-name: rospack
    uri: https://github.com/ros/rospack/archive/2.2.8.tar.gz
    version: rospack-2.2.8
```

I've also validated that this change doesn't break the `--upstream-development` flag when used with a rosdistro cache that does not include the source package xml cache (such as the one at `http://repositories.ros.org/`).