### PR TITLE
Don't require argparse for installation if python is >= 2.7.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,21 @@
 #!/usr/bin/env python
 
 import os
+import sys
 from setuptools import setup, find_packages
+
+install_requires=['catkin_pkg >= 0.1.28', 'rosdistro >= 0.5.0', 'rospkg', 'PyYAML', 'setuptools']
+
+# argparse is a part of the standard library since python 2.7
+if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
+    install_requires.append('argparse')
 
 exec(open(os.path.join(os.path.dirname(__file__), 'src', 'rosinstall_generator', '__init__.py')).read())
 
 setup(
     name='rosinstall_generator',
     version=__version__,
-    install_requires=['argparse', 'catkin_pkg >= 0.1.28', 'rosdistro >= 0.5.0', 'rospkg', 'PyYAML', 'setuptools'],
+    install_requires=install_requires,
     packages=find_packages('src'),
     package_dir={'': 'src'},
     scripts=['bin/rosinstall_generator'],


### PR DESCRIPTION
Currently, I have to `pip install --user argparse` to make `superflore` run on Gentoo, and pip has a tendency to completely ruin the python paths for Gentoo (which is a bummer).

I discovered this in ros/ros-overlay#501.