### PR TITLE
reference the LICENSE.txt from the stdeb.cfg

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,5 +3,6 @@ Depends: python-argparse, python-catkin-pkg (>= 0.1.28), python-rosdistro (>= 0.
 Depends3: python3-catkin-pkg (>= 0.1.28), python3-rosdistro (>= 0.6.8), python3-rospkg, python3-yaml
 Conflicts: python3-rosinstall-generator
 Conflicts3: python-rosinstall-generator
+Copyright-File: LICENSE.txt
 Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic wheezy jessie stretch buster
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
This will cause it to be installed in the debian way