### PR TITLE
remove Ubuntu distros older than Trusty, remove Debian Wheezy

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -4,5 +4,5 @@ Depends3: python3-catkin-pkg (>= 0.1.28), python3-rosdistro (>= 0.6.8), python3-
 Conflicts: python3-rosinstall-generator
 Conflicts3: python-rosinstall-generator
 Copyright-File: LICENSE.txt
-Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic wheezy jessie stretch buster
-X-Python3-Version: >= 3.2
+Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic jessie stretch buster
+X-Python3-Version: >= 3.4


### PR DESCRIPTION
Matching the changes in targeted platforms from ros-infrastructure/catkin_pkg#232.