### PR TITLE
[Windows] Use console_scripts for better cross-platform usage.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,9 @@ setup(
     install_requires=install_requires,
     packages=find_packages('src'),
     package_dir={'': 'src'},
-    scripts=['bin/rosinstall_generator'],
+    entry_points = {
+        'console_scripts': ['rosinstall_generator=rosinstall_generator.cli:main'],
+    },
     author='Dirk Thomas',
     author_email='dthomas@osrfoundation.org',
     maintainer='Dirk Thomas',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,9 @@ setup(
     packages=find_packages('src'),
     package_dir={'': 'src'},
     entry_points = {
-        'console_scripts': ['rosinstall_generator=rosinstall_generator.cli:main'],
+        'console_scripts': [
+            'rosinstall_generator=rosinstall_generator.cli:main',
+        ],
     },
     author='Dirk Thomas',
     author_email='dthomas@osrfoundation.org',

--- a/src/rosinstall_generator/cli.py
+++ b/src/rosinstall_generator/cli.py
@@ -1,4 +1,35 @@
-#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2013, Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Open Source Robotics Foundation, Inc. nor
+#    the names of its contributors may be used to endorse or promote
+#    products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 
 from __future__ import print_function
 
@@ -135,8 +166,3 @@ def main(argv=sys.argv[1:]):
     rosinstall_data = sort_rosinstall(rosinstall_data)
     print(yaml.safe_dump(rosinstall_data, default_flow_style=False))
     return 0
-
-
-if __name__ == '__main__':
-    rc = main()
-    sys.exit(rc)


### PR DESCRIPTION
Switch to use console_scripts to auto generate portable Python scripts.