### PR TITLE
return build_export and buildtool_export dependencies as well

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 import sys
 from setuptools import setup, find_packages
 
-install_requires=['catkin_pkg >= 0.1.28', 'rosdistro >= 0.6.8', 'rospkg', 'PyYAML', 'setuptools']
+install_requires=['catkin_pkg >= 0.1.28', 'rosdistro >= 0.7.3', 'rospkg', 'PyYAML', 'setuptools']
 
 exec(open(os.path.join(os.path.dirname(__file__), 'src', 'rosinstall_generator', '__init__.py')).read())
 

--- a/src/rosinstall_generator/distro.py
+++ b/src/rosinstall_generator/distro.py
@@ -84,7 +84,11 @@ def get_recursive_dependencies(distro, package_names, excludes=None, limit_depth
     try:
         for pkg_name in package_names:
             try:
-                dependencies |= walker.get_recursive_depends(pkg_name, ['buildtool', 'build', 'run', 'test'], ros_packages_only=True, ignore_pkgs=dependencies | excludes, limit_depth=limit_depth)
+                dependencies |= walker.get_recursive_depends(
+                    pkg_name,
+                    ['buildtool', 'buildtool_export', 'build', 'build_export', 'run', 'test'],
+                    ros_packages_only=True,
+                    ignore_pkgs=dependencies | excludes, limit_depth=limit_depth)
             except AssertionError as e:
                 raise RuntimeError("Failed to fetch recursive dependencies of package '%s': %s" % (pkg_name, e))
     finally:
@@ -112,7 +116,10 @@ def get_recursive_dependencies_on(distro, package_names, excludes=None, limit=No
     sys.stderr = CustomLogger()
     try:
         for pkg_name in package_names:
-            dependencies |= walker.get_recursive_depends_on(pkg_name, ['buildtool', 'build', 'run', 'test'], ignore_pkgs=dependencies | excludes)
+            dependencies |= walker.get_recursive_depends_on(
+                pkg_name,
+                ['buildtool', 'buildtool_export', 'build', 'build_export', 'run', 'test'],
+                ignore_pkgs=dependencies | excludes)
     finally:
         sys.stderr = stderr
     dependencies -= set(package_names)

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
-Depends: python-argparse, python-catkin-pkg (>= 0.1.28), python-rosdistro (>= 0.6.8), python-rospkg, python-yaml
-Depends3: python3-catkin-pkg (>= 0.1.28), python3-rosdistro (>= 0.6.8), python3-rospkg, python3-yaml
+Depends: python-argparse, python-catkin-pkg (>= 0.1.28), python-rosdistro (>= 0.7.3), python-rospkg, python-yaml
+Depends3: python3-catkin-pkg (>= 0.1.28), python3-rosdistro (>= 0.7.3), python3-rospkg, python3-yaml
 Conflicts: python3-rosinstall-generator
 Conflicts3: python-rosinstall-generator
 Copyright-File: LICENSE.txt


### PR DESCRIPTION
This PR makes `rosinstall_generator` return also `buildtool_export` and `build_export` dependencies (as opposed to only `build`, `buildtool`, `run` and `test` previously)

Depends on https://github.com/ros-infrastructure/rosdistro/pull/134

Context:

Trying to build ROS 2 Crystal `ros_core`, I used `rosinstall_generator` to get all the sources (`rosinstall_generator ros_core --rosdistro crystal --deps > ros_core.install`). The build fails because of missing `ament_cmake_include_directories` package.
It looks like it's only an exported dependency and not a direct dependency of any package: https://github.com/ament/ament_cmake/blob/d1d73ed440822543981df1f663ee2ed3a023dd40/ament_cmake_target_dependencies/package.xml#L13


Tested on ROS Kinetic for the following packages: `ros_comm`, `desktop`, `desktop_full` and the produced files were identical.
<details><summary>diff for crystal ros_core</summary>

```
>     local-name: ament_cmake/ament_cmake_include_directories
>     uri: https://github.com/ros2-gbp/ament_cmake-release.git
>     version: release/crystal/ament_cmake_include_directories/0.6.1-0
> - git:
113a118,125
>     local-name: ament_lint/ament_cppcheck
>     uri: https://github.com/ros2-gbp/ament_lint-release.git
>     version: release/crystal/ament_cppcheck/0.6.4-0
> - git:
>     local-name: ament_lint/ament_cpplint
>     uri: https://github.com/ros2-gbp/ament_lint-release.git
>     version: release/crystal/ament_cpplint/0.6.4-0
> - git:
133a146,153
>     local-name: ament_lint/ament_uncrustify
>     uri: https://github.com/ros2-gbp/ament_lint-release.git
>     version: release/crystal/ament_uncrustify/0.6.4-0
> - git:
>     local-name: ament_lint/ament_xmllint
>     uri: https://github.com/ros2-gbp/ament_lint-release.git
>     version: release/crystal/ament_xmllint/0.6.4-0
> - git:
201a222,229
>     local-name: googletest/gmock_vendor
>     uri: https://github.com/ros2-gbp/googletest-release.git
>     version: release/crystal/gmock_vendor/1.8.0-0
> - git:
>     local-name: googletest/gtest_vendor
>     uri: https://github.com/ros2-gbp/googletest-release.git
>     version: release/crystal/gtest_vendor/1.8.0-0
> - git:
480a509,512
> - git:
>     local-name: uncrustify_vendor
>     uri: https://github.com/ros2-gbp/uncrustify_vendor-release.git
>     version: release/crystal/uncrustify_vendor/1.1.0-0
```

</details>