### PR TITLE
Add support for --repos ALL

### DIFF
--- a/src/rosinstall_generator/generator.py
+++ b/src/rosinstall_generator/generator.py
@@ -87,12 +87,10 @@ def _classify_repo_names(distro_name, repo_names):
     return names, unknown_names
 
 
-def _get_packages_for_repos(distro_name, repo_names, keywords, source=False):
+def _get_packages_for_repos(distro_name, repo_names, source=False):
     package_names = set([])
     unreleased_repo_names = set([])
     wet_distro = get_wet_distro(distro_name)
-    if ARG_ALL_PACKAGES in keywords:
-        repo_names = wet_distro.repositories.keys()
     for repo_name in repo_names:
         if source:
             # Returns a mapping of package names to package XML strings in particular repo.
@@ -251,14 +249,20 @@ def generate_rosinstall(distro_name, names,
         logger.debug("The following wet packages found in '--from-path' will be considered: %s" % ', '.join(sorted(include_names_from_path)))
         names.update(include_names_from_path)
 
-    # Allow special keywords in repos (like ALL)
+    # Allow special keywords in repos
     repo_names, keywords = _split_special_keywords(repo_names or [])
+    if set(keywords).difference(set([ARG_ALL_PACKAGES])):
+        raise RuntimeError('The only keyword supported by repos is %r' % (ARG_ALL_PACKAGES))
+
+    if ARG_ALL_PACKAGES in keywords:
+        wet_distro = get_wet_distro(distro_name)
+        repo_names = wet_distro.repositories.keys()
 
     # expand repository names into package names
     repo_names, unknown_repo_names = _classify_repo_names(distro_name, repo_names)
     if unknown_repo_names:
         logger.warn('The following unknown repositories will be ignored: %s' % (', '.join(sorted(unknown_repo_names))))
-    wet_package_names, unreleased_repo_names = _get_packages_for_repos(distro_name, repo_names, keywords, source=upstream_source_version)
+    wet_package_names, unreleased_repo_names = _get_packages_for_repos(distro_name, repo_names, source=upstream_source_version)
     names.update(wet_package_names)
     if unreleased_repo_names and not upstream_version_tag and not upstream_source_version:
         logger.warn('The following unreleased repositories will be ignored: %s' % ', '.join(sorted(unreleased_repo_names)))


### PR DESCRIPTION
This enables passing the keyword `ALL` to `--repos` to get all repos in a distribution.

Related, this also fixes a bug where unreleased repos are ignored when using `--upstream-development`.
The release state is unimportant when asked to fetch `source` entries, so this fetches unreleased repo's too.

The result of these two changes is the ability to create a rosinstall file with all Noetic sources.

```
rosinstall_generator --repos ALL --rosdistro noetic --upstream-devel
```