### PR TITLE
Add cosmic, disco, and eoan suites.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -4,5 +4,5 @@ Depends3: python3-catkin-pkg (>= 0.1.28), python3-rosdistro (>= 0.7.3), python3-
 Conflicts: python3-rosinstall-generator
 Conflicts3: python-rosinstall-generator
 Copyright-File: LICENSE.txt
-Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic jessie stretch buster
+Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
 X-Python3-Version: >= 3.4


### PR DESCRIPTION
These are now live on the ROS bootstrap repository and future releases should be pushed to them as well.