### PR TITLE
remove trusty, utopic, vivid, wily from list of suites

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -4,5 +4,5 @@ Depends3: python3-catkin-pkg (>= 0.1.28), python3-rosdistro (>= 0.7.3), python3-
 Conflicts: python3-rosinstall-generator
 Conflicts3: python-rosinstall-generator
 Copyright-File: LICENSE.txt
-Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
+Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
 X-Python3-Version: >= 3.4


### PR DESCRIPTION
Making the latest not-EOL LTS - Xenial - the lowest watermark.