### PR TITLE
`rosinstall_generator ALL` doesn't list anything after 0.1.17 release

### DIFF
--- a/src/rosinstall_generator/generator.py
+++ b/src/rosinstall_generator/generator.py
@@ -257,10 +257,10 @@ def generate_rosinstall(distro_name, names,
 
     # Allow special keywords in repos
     repo_names, repo_keywords = _split_special_keywords(repo_names or [])
-    keywords = _merge_two_keywords(pkg_keywords, repo_keywords)
-    if set(keywords).difference(set([ARG_ALL_PACKAGES])):
+    if set(repo_keywords).difference(set([ARG_ALL_PACKAGES])):
         raise RuntimeError('The only keyword supported by repos is %r' % (ARG_ALL_PACKAGES))
 
+    keywords = _merge_two_keywords(pkg_keywords, repo_keywords)
     if ARG_ALL_PACKAGES in keywords:
         wet_distro = get_wet_distro(distro_name)
         repo_names = wet_distro.repositories.keys()

--- a/src/rosinstall_generator/generator.py
+++ b/src/rosinstall_generator/generator.py
@@ -212,6 +212,12 @@ def _get_package_names(path):
     return set([pkg.name for _, pkg in find_packages_allowing_duplicates(path).items()])
 
 
+def _merge_two_keywords(x, y):
+    z = x.copy()
+    z = z.update(y)
+    return z
+
+
 _wet_distro = None
 _dry_distro = None
 
@@ -240,7 +246,7 @@ def generate_rosinstall(distro_name, names,
     upstream_version_tag=False, upstream_source_version=False):
 
     # classify package/stack names
-    names, keywords = _split_special_keywords(names)
+    names, pkg_keywords = _split_special_keywords(names)
 
     # find packages recursively in include paths
     if from_paths:
@@ -250,7 +256,8 @@ def generate_rosinstall(distro_name, names,
         names.update(include_names_from_path)
 
     # Allow special keywords in repos
-    repo_names, keywords = _split_special_keywords(repo_names or [])
+    repo_names, repo_keywords = _split_special_keywords(repo_names or [])
+    keywords = _merge_two_keywords(pkg_keywords, repo_keywords)
     if set(keywords).difference(set([ARG_ALL_PACKAGES])):
         raise RuntimeError('The only keyword supported by repos is %r' % (ARG_ALL_PACKAGES))
 

--- a/src/rosinstall_generator/generator.py
+++ b/src/rosinstall_generator/generator.py
@@ -212,12 +212,6 @@ def _get_package_names(path):
     return set([pkg.name for _, pkg in find_packages_allowing_duplicates(path).items()])
 
 
-def _merge_two_keywords(x, y):
-    z = x.copy()
-    z = z.update(y)
-    return z
-
-
 _wet_distro = None
 _dry_distro = None
 
@@ -260,8 +254,7 @@ def generate_rosinstall(distro_name, names,
     if set(repo_keywords).difference(set([ARG_ALL_PACKAGES])):
         raise RuntimeError('The only keyword supported by repos is %r' % (ARG_ALL_PACKAGES))
 
-    keywords = _merge_two_keywords(pkg_keywords, repo_keywords)
-    if ARG_ALL_PACKAGES in keywords:
+    if ARG_ALL_PACKAGES in repo_keywords:
         wet_distro = get_wet_distro(distro_name)
         repo_names = wet_distro.repositories.keys()
 
@@ -280,8 +273,8 @@ def generate_rosinstall(distro_name, names,
     names, unknown_names = _classify_names(distro_name, names, source=upstream_source_version)
     if unknown_names:
         logger.warn('The following unreleased packages/stacks will be ignored: %s' % (', '.join(sorted(unknown_names))))
-    if keywords:
-        expanded_names, unknown_names = _classify_names(distro_name, _expand_keywords(distro_name, keywords), source=upstream_source_version)
+    if pkg_keywords:
+        expanded_names, unknown_names = _classify_names(distro_name, _expand_keywords(distro_name, pkg_keywords), source=upstream_source_version)
         if unknown_names:
             logger.warn('The following unreleased packages/stacks from the %s will be ignored: %s' % (ROS_PACKAGE_PATH, ', '.join(sorted(unknown_names))))
         names.update(expanded_names)
@@ -293,12 +286,12 @@ def generate_rosinstall(distro_name, names,
         logger.debug('Unreleased repositories: %s' % ', '.join(sorted(unreleased_repo_names)))
 
     # classify deps-up-to
-    deps_up_to_names, keywords = _split_special_keywords(deps_up_to or [])
+    deps_up_to_names, deps_keywords = _split_special_keywords(deps_up_to or [])
     deps_up_to_names, unknown_names = _classify_names(distro_name, deps_up_to_names, source=upstream_source_version)
     if unknown_names:
         logger.warn("The following unreleased '--deps-up-to' packages/stacks will be ignored: %s" % (', '.join(sorted(unknown_names))))
-    if keywords:
-        expanded_names, unknown_names = _classify_names(distro_name, _expand_keywords(distro_name, keywords), source=upstream_source_version)
+    if deps_keywords:
+        expanded_names, unknown_names = _classify_names(distro_name, _expand_keywords(distro_name, deps_keywords), source=upstream_source_version)
         if unknown_names:
             logger.warn("The following unreleased '--deps-up-to' packages/stacks from the %s will be ignored: %s" % (ROS_PACKAGE_PATH, ', '.join(sorted(unknown_names))))
         deps_up_to_names.update(expanded_names)
@@ -306,7 +299,7 @@ def generate_rosinstall(distro_name, names,
         logger.debug('Dependencies up to: %s' % ', '.join(sorted(deps_up_to_names.wet_package_names | deps_up_to_names.dry_stack_names)))
 
     # classify excludes
-    exclude_names, keywords = _split_special_keywords(excludes or [])
+    exclude_names, excludes_keywords = _split_special_keywords(excludes or [])
     if exclude_paths:
         exclude_names_from_path = set([])
         [exclude_names_from_path.update(_get_package_names(exclude_path)) for exclude_path in exclude_paths]
@@ -315,8 +308,8 @@ def generate_rosinstall(distro_name, names,
     exclude_names, unknown_names = _classify_names(distro_name, exclude_names, source=upstream_source_version)
     if unknown_names:
         logger.warn("The following unreleased '--exclude' packages/stacks will be ignored: %s" % (', '.join(sorted(unknown_names))))
-    if keywords:
-        expanded_names, unknown_names = _classify_names(distro_name, _expand_keywords(distro_name, keywords), source=upstream_source_version)
+    if excludes_keywords:
+        expanded_names, unknown_names = _classify_names(distro_name, _expand_keywords(distro_name, excludes_keywords), source=upstream_source_version)
         exclude_names.update(expanded_names)
     if excludes:
         logger.debug('Excluded packages/stacks: %s' % ', '.join(sorted(exclude_names.wet_package_names | exclude_names.dry_stack_names)))


### PR DESCRIPTION
After `0.1.17` release, a `keywords` variable from `_split_special_keywords(names)` is not being evaluated against the special keyword of `ALL`, and it results in a regression where you cannot do `rosinstall_generator ALL` (like the example shown in `4.4 All packages of a ROS distribution from released sources` of this [Wiki](http://wiki.ros.org/rosinstall_generator) page.)

This fixes #59