### PR TITLE
add Python 3.7 and 3.8 to Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 install:
   - pip install argparse catkin-pkg rosdistro rospkg PyYAML setuptools coverage


### PR DESCRIPTION
Since Debian Buster uses Python 3.7 and Ubuntu Focal targets Python 3.8.