### PR TITLE
distro: include vcs_type when generating rosinstall

### DIFF
--- a/src/rosinstall_generator/distro.py
+++ b/src/rosinstall_generator/distro.py
@@ -142,7 +142,7 @@ def _generate_rosinstall_for_package(distro, pkg_name, flat=False, tar=False):
     if not flat and repo.package_names != [pkg_name]:
         local_name = '%s/%s' % (repo.name, local_name)
     release_tag = get_release_tag(repo, pkg_name)
-    return _generate_rosinstall(local_name, repo.url, release_tag, tar=tar)
+    return _generate_rosinstall(local_name, repo.url, release_tag, tar=tar, vcs_type=repo.type)
 
 
 def _generate_rosinstall(local_name, url, release_tag, tar=False, vcs_type=None):


### PR DESCRIPTION
`_generate_rosinstall()` nicely supports multiple VCS types, but the repo type isn't currently passed, which means everything is assumed to be git. rosinstall supports far more than that. This PR fixes this by passing the VCS type, thereby allowing rosinstall_generator to support them as well.