### PR TITLE
pin PyYAML for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
   - "3.8"
 
 install:
+  - if [ $TRAVIS_PYTHON_VERSION == "3.4" ]; then pip install PyYAML==5.2; fi
   - pip install argparse catkin-pkg rosdistro rospkg PyYAML setuptools coverage
 
 script:


### PR DESCRIPTION
Fix CI failure with Python 3.4 since newer versions of `PyYAML` don't support Python 3.4 anymore.