### PR TITLE
document --repos ALL, avoid exception for repos without source entry

### DIFF
--- a/src/rosinstall_generator/cli.py
+++ b/src/rosinstall_generator/cli.py
@@ -63,7 +63,7 @@ def main(argv=sys.argv[1:]):
     parser.add_argument('--from-path', type=_existing_directory, nargs='*',
         help="Add a set of catkin packages found recursively under the given path as if they would have been passed as 'package_names'.")
     parser.add_argument('--repos', nargs='*', metavar='reponame',
-        help='Repository names containing catkin packages.')
+        help="Repository names containing catkin packages. Use '%s' to specify all release packages (only usable as a single argument)." % ARG_ALL_PACKAGES)
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--upstream', action='store_true', default=False,

--- a/src/rosinstall_generator/generator.py
+++ b/src/rosinstall_generator/generator.py
@@ -93,6 +93,8 @@ def _get_packages_for_repos(distro_name, repo_names, source=False):
     wet_distro = get_wet_distro(distro_name)
     for repo_name in repo_names:
         if source:
+            if not wet_distro.repositories[repo_name].source_repository:
+                continue
             # Returns a mapping of package names to package XML strings in particular repo.
             source_package_xmls = wet_distro.get_source_repo_package_xmls(repo_name)
         if source and source_package_xmls:


### PR DESCRIPTION
Which allows to call:

```
rosinstall_generator --rosdistro rolling --repos ALL --upstream-development
```

to get e.g. the repository `system_tests` which has a `source` entry but no `release` entry.