### PR TITLE
Depend on `-modules` apt packages

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
-Depends: python-argparse, python-catkin-pkg (>= 0.1.28), python-rosdistro (>= 0.7.3), python-rospkg, python-yaml
-Depends3: python3-catkin-pkg (>= 0.1.28), python3-rosdistro (>= 0.7.3), python3-rospkg, python3-yaml
+Depends: python-argparse, python-catkin-pkg-modules (>= 0.1.28), python-rosdistro-modules (>= 0.7.3), python-rospkg-modules, python-yaml
+Depends3: python3-catkin-pkg-modules (>= 0.1.28), python3-rosdistro-modules (>= 0.7.3), python3-rospkg-modules, python3-yaml
 Conflicts: python3-rosinstall-generator
 Conflicts3: python-rosinstall-generator
 Copyright-File: LICENSE.txt


### PR DESCRIPTION
`rosinstall_generator` doesn't use the CLI tools from `catkin-pkg`, `rosdistro`, and `rospkg`; it only uses the python modules. This PR should make it possible to install `python-rosinstall-generator` and `python3-rosinstall-generator` side-by-side.