### PR TITLE
Update release distributions.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -4,7 +4,7 @@ Depends3: python3-catkin-pkg (>= 0.1.28), python3-rosdistro (>= 0.7.3), python3-
 Conflicts: python3-rosinstall-generator
 Conflicts3: python-rosinstall-generator
 Copyright-File: LICENSE.txt
-Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
-Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal jessie stretch buster
+Suite: bionic cosmic disco eoan buster
+Suite3: bionic cosmic disco eoan focal jammy buster bullseye
 Python2-Depends-Name: python
 X-Python3-Version: >= 3.4


### PR DESCRIPTION
* Drop Ubuntu Xenial and adjacent non-LTS distributions
* Drop Debian Jessie and Stretch which are no longer supported upstream
* Add Debian Bullseye
* Add Ubuntu Jammy