### PR TITLE
Run tests with pytest instead of nose

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,0 @@
-[run]
-include =
-    src/rosinstall_generator/*
-
-[report]
-show_missing = True

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
           python-version: ${{matrix.python}}
       - name: Install dependencies
         run: |
-          python -m pip install argparse catkin-pkg nose rosdistro rospkg PyYAML setuptools coverage
+          python -m pip install argparse catkin-pkg pytest pytest-cov rosdistro rospkg PyYAML setuptools coverage
       - name: Run tests
         run: |
-          python -m nose --with-coverage
+          python -m pytest test --cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[tool:pytest]
+junit_suite_name = rosinstall_generator
+
+[coverage:run]
+source = rosinstall_generator

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'src'))


### PR DESCRIPTION
Official nose documentation recommends users migrate to a more supported platform.