### PR TITLE
Drop 'setuptools' dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,17 @@ import os
 import sys
 from setuptools import setup, find_packages
 
-install_requires=['catkin_pkg >= 0.1.28', 'rosdistro >= 0.7.3', 'rospkg', 'PyYAML', 'setuptools']
-
 exec(open(os.path.join(os.path.dirname(__file__), 'src', 'rosinstall_generator', '__init__.py')).read())
 
 setup(
     name='rosinstall_generator',
     version=__version__,
-    install_requires=install_requires,
+    install_requires=[
+        'catkin_pkg >= 0.1.28',
+        'PyYAML',
+        'rosdistro >= 0.7.3',
+        'rospkg',
+    ],
     packages=find_packages('src'),
     package_dir={'': 'src'},
     entry_points = {


### PR DESCRIPTION
I can't find a reason to have this runtime dependency, and it isn't present in stdeb.cfg anyway.

Also move the 'install_requires' with the other setup data to simplify the setup.py. This was present to facilitate the conditional addition of 'argparse' for Python <= 2.6, which was dropped in a previous change.