### PR TITLE
Use a 'raw' string in a regex

### DIFF
--- a/src/rosinstall_generator/distro.py
+++ b/src/rosinstall_generator/distro.py
@@ -152,7 +152,7 @@ def _generate_rosinstall(local_name, url, release_tag, tar=False, vcs_type=None)
         # Github tarball:    https://github.com/ros/ros_comm/archive/1.11.20.tar.gz
         # Bitbucket tarball: https://bitbucket.org/osrf/gazebo/get/gazebo7_7.3.1.tar.gz
         # Gitlab tarball:    https://gitlab.com/gitlab-org/gitlab-ce/-/archive/master/archive.tar.gz
-        match = re.match('(?:\w+:\/\/|git@)([\w.-]+)[:/]([\w./-]*?)(?:\.git)?$', url)
+        match = re.match(r'(?:\w+:\/\/|git@)([\w.-]+)[:/]([\w./-]*?)(?:\.git)?$', url)
 
         if match:
             server, repo_path = match.groups()


### PR DESCRIPTION
Should resolve:
```
src/rosinstall_generator/distro.py:155
  /home/cottsay/rosinstall_generator/src/rosinstall_generator/distro.py:155: DeprecationWarning: invalid escape sequence '\w'
    match = re.match('(?:\w+:\/\/|git@)([\w.-]+)[:/]([\w./-]*?)(?:\.git)?$', url)
```

This regular expression is well covered by tests.