### PR TITLE
Avoid an assert when running into entries that have no release version.

### DIFF
--- a/src/rosinstall_generator/generator.py
+++ b/src/rosinstall_generator/generator.py
@@ -101,7 +101,7 @@ def _get_packages_for_repos(distro_name, repo_names, source=False):
             package_names.update(source_package_xmls.keys())
         else:
             release_repo = wet_distro.repositories[repo_name].release_repository
-            if release_repo:
+            if release_repo and release_repo.version:
                 package_names.update(release_repo.package_names)
             else:
                 unreleased_repo_names.add(repo_name)


### PR DESCRIPTION
A relatively new standard operating practice in the distro files in https://github.com/ros/rosdistro is to leave released packages in place, but to remove their version numbers for known-failing versions.  Unfortunately, this was tripping up the assert in _generate_rosinstall_for_package, since that assumed that the release repository entry had a version.

Fix it here by causing repositories setup this way to behave like "unreleased" repositories, which I think makes sense. That avoids the assert and allows it to succeed.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix running `rosinstall_generator` against current Rolling, like the following:

```
$ rosinstall_generator --repos ALL --rosdistro rolling --deps
The following unreleased repositories will be ignored: mir_robot, mvsim, system_tests
Traceback (most recent call last):
  File "/home/ubuntu/.local/bin/rosinstall_generator", line 8, in <module>
    sys.exit(main())
  File "/home/ubuntu/.local/lib/python3.10/site-packages/rosinstall_generator/cli.py", line 155, in main
    rosinstall_data = generate_rosinstall(args.rosdistro, args.package_names,
  File "/home/ubuntu/.local/lib/python3.10/site-packages/rosinstall_generator/generator.py", line 454, in generate_rosinstall
    wet_rosinstall_data = generate_wet_rosinstall(wet_distro, result.wet_package_names, flat=flat, tar=tar)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/rosinstall_generator/distro.py", line 132, in generate_rosinstall
    rosinstall_data.extend(_generate_rosinstall_for_package(distro, pkg_name, flat=flat, tar=tar))
  File "/home/ubuntu/.local/lib/python3.10/site-packages/rosinstall_generator/distro.py", line 139, in _generate_rosinstall_for_package
    assert repo is not None and repo.version is not None, 'Package "%s" does not have a version"' % pkg_name
AssertionError: Package "ign_rviz_common" does not have a version"
```

Instead, it will now succeed with:

```
$ rosinstall_generator --repos ALL --rosdistro rolling --deps
The following unreleased repositories will be ignored: ign_rviz, mir_robot, mvsim, ros1_bridge, rosbag2_bag_v2, system_tests, warehouse_ros_mongo
- git:
    local-name: SMACC2/smacc2
    uri: https://github.com/ros2-gbp/SMACC2-release.git
    version: release/rolling/smacc2/0.4.0-1
...
```